### PR TITLE
[temp.constr] Add missing word.

### DIFF
--- a/temp.html
+++ b/temp.html
@@ -915,7 +915,7 @@ false
     calls a function concept or refers to a variable concept 
     <cxx-ref to="dcl.concept"></cxx-ref> is a <dfn>concept check</dfn>.
     A concept check is not evaluated; it is simplified according to the
-    rules described in this.</p>
+    rules described in this section.</p>
 
     <p>Certain subexpressions of a
     <cxx-grammarterm>constraint-expression</cxx-grammarterm> are 


### PR DESCRIPTION
Could use "sub-clause" instead, but see cplusplus/draft/issues/307 (IMHO)
