### PR TITLE
Make example in 7.1.6.4 more meaningful.

### DIFF
--- a/dcl.dcl.html
+++ b/dcl.dcl.html
@@ -88,10 +88,10 @@
 
         <cxx-example class="inline">
         <cxx-codeblock>
-namespace N {
+struct N {
   template&lt;typename T&gt; struct Wrap;
-  template&lt;typename T&gt; Wrap<T> make_wrap(T);
-}
+  template&lt;typename T&gt; static Wrap<T> make_wrap(T);
+};
 template&lt;typename T, typename U&gt; struct Pair;
 template&lt;typename T, typename U&gt; Pair&lt;T, U&gt; make_pair(T, U);
 template&lt;int N&gt; struct Size { };


### PR DESCRIPTION
In section **7.1.6.4 `auto` specifier**:

``` cpp
namespace N {
  template<typename T> struct Wrap;
  template<typename T> Wrap make_wrap(T);
}
/* ... */
auto::Wrap<int> x = N::make_wrap(0); // error: auto used in a non-deduced context
```

This error case would be more meaningful if `N` is a `struct`, since `auto` cannot be a placeholder for a `namespace` anyway.
