### PR TITLE
Fix auto wording

### DIFF
--- a/dcl.dcl.html
+++ b/dcl.dcl.html
@@ -260,7 +260,8 @@ template&lt;typename T&gt; concept bool C() {
         </del>
 
         <ins>
-        Either <code>auto</code> shall appear in the 
+        Either <code>auto</code> shall appear in one of the
+        <cxx-grammarterm>decl-specifier</cxx-grammarterm>s in the
         <cxx-grammarterm>decl-specifier-seq</cxx-grammarterm>, or
         <code>decltype(auto)</code> shall appear as one of the
         <cxx-grammarterm>decl-specifier</cxx-grammarterm>s in the


### PR DESCRIPTION
`auto` is still restricted to one of the _decl-specifier_ s in the _decl-specifier-seq_. My understanding of the intent of this change is to make `auto` appear **in** a _decl-specifier_ rather than **as**.
