### PR TITLE
Missing terminals in grammar for template-introduction.

### DIFF
--- a/temp.html
+++ b/temp.html
@@ -496,7 +496,7 @@ template&lt;C5... Cs&gt; f6();      // <i>OK:</i> Cs <i>is a template parameter 
         <bnf-alt>
           <bnf-opt>nested-name-specifier</bnf-opt>
           concept-name
-          introduction-list
+          <bnf-terminal>{</bnf-terminal> introduction-list <bnf-terminal>}</bnf-terminal>
         </bnf-alt>
 
       <bnf-rule>introduction-list</bnf-rule>


### PR DESCRIPTION
Add missing left and right brace terminals in the grammar production for template-introduction.
