### PR TITLE
Correct word mis-ordering in [expr.prim.req]/3.

### DIFF
--- a/src/expressions.tex
+++ b/src/expressions.tex
@@ -328,7 +328,7 @@ A \grammarterm{requires-expression} has type \tcode{bool} and is an
 unevaluated expression (\ref{expr}).
 \enternote
 A \grammarterm{requires-expression} is transformed into a constraint 
-(\ref{temp.constr.decl}) to in order determine if it is 
+(\ref{temp.constr.decl}) in order to determine if it is 
 satisfied (\ref{temp.constr}).
 \exitnote
 


### PR DESCRIPTION
"to in order" ==> "in order to"