### PR TITLE
s/associated constrains/associated constraints/

### DIFF
--- a/src/overloading.tex
+++ b/src/overloading.tex
@@ -45,7 +45,7 @@ overloaded: ...
 \rSec2[over.dcl]{Declaration matching}
 
 Modify paragraph 1 to extend the notion of declaration matching to
-also include a function's associated constrains. Note that the
+also include a function's associated constraints. Note that the
 example in the original text is omitted in this document.
 
 \begin{quote}

--- a/src/templates.tex
+++ b/src/templates.tex
@@ -1059,7 +1059,7 @@ involving template parameters.
 Two function templates are \defn{functionally equivalent} if they 
 are equivalent except that one or more expressions that involve 
 template parameters in the return types\added{,} \removed{and} parameter 
-lists\added{, and associated constrains (\ref{temp.constr.decl})}
+lists\added{, and associated constraints (\ref{temp.constr.decl})}
 are functionally equivalent using the rules described above to compare 
 expressions involving template parameters.
 % 


### PR DESCRIPTION
Typo fixes for [over.dcl] and [temp.over.link].