### PR TITLE
Updated the document and revision numbers in the TS header.

### DIFF
--- a/src/config.tex
+++ b/src/config.tex
@@ -1,8 +1,8 @@
 %!TEX root = std.tex
 %%--------------------------------------------------
 %% Version numbers
-\newcommand{\docno}{N4553}
-\newcommand{\prevdocno}{N4549}
+\newcommand{\docno}{N4630}
+\newcommand{\prevdocno}{N4553}
 \newcommand{\cppver}{201509L}
 
 %% Title


### PR DESCRIPTION
It appears that the document and revision numbers were not updated for the N4630 publication.