### PR TITLE
Modify requires-clause grammar syntax

### DIFF
--- a/src/constraints.tex
+++ b/src/constraints.tex
@@ -226,7 +226,7 @@ whose operands are in the following order:
       by a \grammarterm{requires-clause} following a 
       \grammarterm{template-parameter-list} (Clause~\ref{temp}), and
 
-\item the \grammarterm{constraint-expression} of a trailing 
+\item the \grammarterm{constraint-expression} introduced by a trailing 
       \grammarterm{requires-clause} (Clause~\ref{dcl.decl}) 
       of a function declaration (\ref{dcl.fct}).
 \end{itemize}

--- a/src/declarators.tex
+++ b/src/declarators.tex
@@ -86,6 +86,10 @@ precede a \grammarterm{trailing-return-type}.
 % 
 When present in a \grammarterm{declarator}, the \grammarterm{requires-clause} 
 is called the \defn{trailing \grammarterm{requires-clause}{}}.
+The trailing \grammarterm{requires-clause} introduces the
+\grammarterm{constraint-expression} that results from interpreting
+its \grammarterm{constraint-logical-or-expression} as a
+\grammarterm{constraint-expression}.
 % 
 \enterexample
 \begin{codeblock}

--- a/src/expressions.tex
+++ b/src/expressions.tex
@@ -413,13 +413,13 @@ that \tcode{g(x)} is non-throwing.
 
 \begin{bnf}
 \nontermdef{nested-requirement}\br
-    requires-clause \terminal{;}
+    \terminal{requires} constraint-expression \terminal{;}
   \end{bnf}
 
 \pnum
 A \grammarterm{nested-requirement} can be used
 to specify additional constraints in terms of local parameters.
-The \grammarterm{constraint-expression} of the \grammarterm{requires-clause} 
+The \grammarterm{constraint-expression}
 shall be satisfied (\ref{temp.constr.decl}) by the substituted template
 arguments, if any.
 Substitution of template arguments into a \grammarterm{nested-requirement}

--- a/src/templates.tex
+++ b/src/templates.tex
@@ -23,14 +23,22 @@ family of types.
 \end{addedblock}
 
 \begin{addedblock}
-\nontermdef{requires-clause}\br
-  \terminal{requires} constraint-expression
-
 \nontermdef{concept-definition}\br
   \terminal{concept} concept-name \terminal{=} constraint-expression
 
 \nontermdef{concept-name}\br
   identifier
+
+\nontermdef{requires-clause}\br
+  \terminal{requires} constraint-logical-or-expression
+
+\nontermdef{constraint-logical-and-expression}\br
+  primary-expression\br
+  constraint-logical-and-expression \terminal{\&\&} primary-expression
+
+\nontermdef{constraint-logical-or-expression}\br
+  constraint-logical-and-expression\br
+  constraint-logical-or-expression \terminal{||} constraint-logical-and-expression
 \end{addedblock}
 \end{bnf}
 \end{quote}
@@ -47,6 +55,10 @@ parameters.
 The optional \grammarterm{requires-clause} following a
 \grammarterm{template-parameter-list} allows the specification of
 constraints (\ref{temp.constr.decl}) on template arguments (\ref{temp.arg}).
+The \grammarterm{requires-clause} introduces the
+\grammarterm{constraint-expression} that results from interpreting
+the \grammarterm{constraint-logical-or-expression} as a
+\grammarterm{constraint-expression}.
 \end{addedblock}
 \end{quote}
 


### PR DESCRIPTION
Break _nested-requirement_ dependency on _requires-clause_,
avoid [temp.constr.decl] reference to _constraint-expression_ of a _requires-clause_ (no such thing),
in a _template-head_, we need to introduce a _constraint-expression_; and
in a trailing _requires-clause_, we need to introduce a _constraint-expression_.