### PR TITLE
Disallow constrained concept definitions

### DIFF
--- a/src/templates.tex
+++ b/src/templates.tex
@@ -855,7 +855,10 @@ T f2(T x) { return x; }
 
 \pnum
 A \grammarterm{concept-definition} shall appear in the global scope or in a
-namespace scope \cxxref{basic.scope.namespace}.
+namespace scope (\cxxref{basic.scope.namespace}).
+
+\pnum
+A concept shall not have associated constraints (\ref{temp.constr.decl}).
 
 \pnum
 A concept is not instantiated (\ref{temp.spec}). 


### PR DESCRIPTION
In [temp.concept], add a constraint that a concept shall not have associated constraints.

Add parentheses to a cross-reference as a drive-by.